### PR TITLE
add IN_MOVED_TO support like logrotate empty file create

### DIFF
--- a/lib/File/Tail/Inotify2.pm
+++ b/lib/File/Tail/Inotify2.pm
@@ -12,7 +12,7 @@ our $VERSION = '1.00';
 
 use constant {
     FMASK => IN_MODIFY | IN_MOVE_SELF,
-    DMASK => IN_CREATE | IN_MOVED_FROM,
+    DMASK => IN_CREATE | IN_MOVED_FROM | IN_MOVED_TO,
 };
 
 sub new {
@@ -100,7 +100,7 @@ sub _set_dir_watcher {
             if ( $event->IN_MOVED_FROM && $event->fullname eq $self->{file} ) {
                 $self->{in_move} = 1;
             }
-            if ( $event->IN_CREATE && $event->fullname eq $self->{file} ) {
+            if ( ($event->IN_CREATE || $event->IN_MOVED_TO) && $event->fullname eq $self->{file} ) {
                 $self->{curpos} = (stat $event->fullname)[7];
                 $self->_set_file_watcher;
                 $self->{in_move} = 0;


### PR DESCRIPTION
logrotate で nocreateを指定していないファイルをtailしている場合、
```
rename("logfile", "logfile-20180327")
open("logrotate_temp.8UZy8E", O_RDWR|O_CREAT|O_EXCL, 0600)
rename("logrotate_temp.8UZy8E", "logfile")
```
といった動きをするため、追従できない
そこで、 IN_MOVED_TO もチェックして _set_file_watcher しなおすようにした